### PR TITLE
streamline API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mongo-bulk-writable
-expose mongodb BulkOp as a writable stream
+Expose mongodb BulkOp as a writable stream
 
 ## Install 
 
@@ -12,9 +12,12 @@ Simple use case :
 ```js
 var BulkWritable = require('mongo-bulk-writable');
 var col; // get a collection object from driver
-var writable = new BulkWritable(col.initializeOrderedBulkOp(), function write(chunk, next) {
-  this.bulk.insert(chunk);
-  next();
+var writable = new BulkWritable( {
+    collection :col,
+    callback: function write(bulk, chunk, next) {
+      bulk.insert(chunk);
+      next();
+    }
 });
 // pipe it
 req.pipe(writable);
@@ -25,9 +28,16 @@ Or
 ```js
 var BulkWritable = require('mongo-bulk-writable');
 var col; // get a collection object from driver
-var writable = new BulkWritable(col.initializeUnorderedBulkOp(), function write(chunk, next) {
-  this.bulk.find( { status: "P" } ).update( { $set: { comment: chunk.comment} } );
-  next();
+var writable = new BulkWritable( {
+  collection: col,
+  ordered: true,
+  callback: function write(bulk, chunk, next) {
+    bulk
+      .find( { status: "P" } )
+      .update( { $set: { comment: chunk.comment} } );
+    next();
+  },
+  highWaterMark: 10000
 });
 // pipe it
 req.pipe(writable);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,41 +1,42 @@
-/*jslint node: true, nomen: true, plusplus: true, vars: true, eqeq: true*/
 'use strict';
+const Writable = require('flushwritable');
 
-var Writable = require('flushwritable'),
-    util = require('util');
-
-function BulkWriteStream(bulk, opts, withbulk) {
-    if (typeof opts == 'function') {
-        withbulk = opts;
-        opts = {};
-    }
-    Writable.call(this, {
-        objectMode: true,
-        highWaterMark: (opts.highWaterMark == null ? 16 : opts.highWaterMark)
-    });
-    this.bulk = bulk;
-    this.isEmpty = true;
-    this.withbulk = withbulk.bind(this);
-}
-util.inherits(BulkWriteStream, Writable);
-
-BulkWriteStream.prototype._write = function (chunk, enc, next) {
-    this.isEmpty = false;
-    this.withbulk(chunk, next);
-};
-
-BulkWriteStream.prototype._flush = function (next) {
-    if (!this.isEmpty) {
-        try {
-            return this.bulk.execute(next);
-        } catch (e) {
-            this.emit('error', e);
+class MongoBulkWriteStream extends Writable {
+    constructor(opts) {
+        if (!opts || !opts.collection || !opts.callback) {
+            throw new Error('collection and callback are mandatory options');
         }
-    } else {
-        next();
+        super({
+            objectMode: true,
+            highWaterMark: (
+                opts.highWaterMark === undefined ?
+                    1000 :
+                    Number(opts.highWaterMark)
+            )
+        });
+        this._cb = opts.callback;
+        this._isEmpty = true;
+        this._bulk = opts.ordered ?
+            opts.collection.initializeOrderedBulkOp() :
+            opts.collection.initializeUnorderedBulkOp();
     }
-};
 
-module.exports = function (bulk, opts, withbulk) {
-    return new BulkWriteStream(bulk, opts, withbulk);
-};
+    _write(chunk, enc, next) {
+        this._isEmpty = false;
+        this._cb(this._bulk, chunk, next);
+    }
+
+    _flush(next) {
+        if (!this._isEmpty) {
+            try {
+                return this._bulk.execute(next);
+            } catch (e) {
+                this.emit('error', e);
+            }
+        } else {
+            next();
+        }
+    }
+}
+
+module.exports = MongoBulkWriteStream;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mongo-bulk-writable",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "expose mongodb BulkOp as a writable stream",
   "main": "lib/index.js",
   "scripts": {
-    "test": "nodeunit test/*.test.js"
+    "test": "mocha test"
   },
   "repository": {
     "type": "git",
@@ -24,9 +24,10 @@
   },
   "homepage": "https://github.com/bimedia-fr/mongo-bulk-writable#readme",
   "devDependencies": {
+    "chai": "^3.5.0",
     "event-stream": "^3.3.3",
-    "mongodb": "^2.2.0",
-    "nodeunit": "^0.9.1"
+    "mocha": "^3.2.0",
+    "mongodb": "^2.2.0"
   },
   "dependencies": {
     "flushwritable": "^1.0.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,89 +3,101 @@
 
 var MongoClient = require('mongodb').MongoClient;
 var es = require('event-stream');
-var bulkWritable = require('../lib/index');
+var MongoBulkWriteStream = require('../lib/index');
+var arr = require('./sample.js');
+var expect = require('chai').expect;
 
 // Connection URL
 var url = 'mongodb://localhost:27017/myproject';
 
 var db, col;
+describe('Simple Case', () => {
 
-module.exports = {
-    setUp: function (done) {
-
-        MongoClient.connect(url, function (err, mongo) {
-            if (err) {
+    beforeEach((done) => {
+        MongoClient.connect(url)
+            .then((mongo) => {
+                db = mongo;
+                col = db.collection('test');
+            })
+            .then( () => {
+                col.drop();
+            })
+            .catch( (err) => {
                 console.log(err);
-            }
-            db = mongo;
-            col = db.collection('test' + (Date.now() % 10));
-            done();
-        });
-    },
-    testSimpleCase: function (test) {
-        var arr = require('./sample.js');
-        var reader = es.readArray(arr), bulk = col.initializeOrderedBulkOp();
-        var writable = bulkWritable(bulk, function write(chunk, next) {
-            this.bulk.insert(chunk);
-            next();
+            })
+            .then( () => {
+                done();
+            })
+    });
+
+    afterEach(() => {
+        if (db) {
+            db.close();
+        }
+    })
+    it('should insert 21 records with pipe', (done) => {
+        var reader = es.readArray(arr);
+        var writable = new MongoBulkWriteStream({
+            callback:  function write(bulk, chunk, next) {
+                bulk.insert(chunk);
+                next();
+            },
+            collection: col
         });
         writable.on('finish', function () {
             col.find({}).toArray(function (err, res) {
-                test.equal(res.length, 21);
-                test.done();
+                expect(res).to.have.lengthOf(21);
+                done();
             });
         });
         writable.on('error', function (err) {
             console.log(err);
-            test.done(err);
+            done(err);
         });
         reader.pipe(writable);
-    },
-    testWrite: function (test) {
-        var arr = require('./sample.js');
-        var reader = es.readArray(arr), bulk = col.initializeOrderedBulkOp();
-        var writable = bulkWritable(bulk, function write(chunk, next) {
-            this.bulk.insert(chunk);
-            next();
-        });
+    });
 
+    it('should insert 21 records with write', (done) => {
+        var reader = es.readArray(arr);
+        var writable = new MongoBulkWriteStream({
+            callback:  function write(bulk, chunk, next) {
+                bulk.insert(chunk);
+                next();
+            },
+            collection: col
+        });
         writable.on('error', function (err) {
-            console.log(err);
-            test.done(err);
+            done(err);
         });
-
-        //reader.pipe(writable);
         arr.forEach(function (el) {
             writable.write(el);
         });
 
         writable.end(function () {
             col.find({}).toArray(function (err, res) {
-                test.equal(res.length, 21);
-                test.done();
+                expect(res).to.have.lengthOf(21);
+                done();
             });
         });
-    },
-    testEmptyBulk: function (test) {
-        var reader = es.readArray([]), bulk = col.initializeOrderedBulkOp();
-        var writable = bulkWritable(bulk, function write(chunk, next) {
-            this.bulk.insert(chunk);
-            next();
+    });
+
+    it('should insert empty records without issue', (done) => {
+        var reader = es.readArray([]);
+        var writable = new MongoBulkWriteStream({
+            callback:  function write(bulk, chunk, next) {
+                bulk.insert(chunk);
+                next();
+            },
+            collection: col
         });
         writable.on('finish', function () {
-            test.done();
+            done();
         });
         writable.on('error', function (err) {
-            console.log(err);
-            test.done(err);
+            done(err);
         });
         reader.pipe(writable);
-    },
-    tearDown: function (done) {
-        if (db) {
-            col.drop();
-            db.close();
-        }
-        done();
-    }
-};
+    });
+
+    
+});


### PR DESCRIPTION
I have created a PR with a more streamlined api. 

Instead of exposing `bulk` through `this` in the callback function - we directly expose it as the first argument. 

Also making the write stream ensure that it creates the bulk operation that it exposes to the outside world.   